### PR TITLE
[MRELEASE-1045] Update mockito-core to 2.28.2

### DIFF
--- a/maven-release-plugin/pom.xml
+++ b/maven-release-plugin/pom.xml
@@ -103,6 +103,7 @@
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
+      <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
Changed the pom.xml in maven-release-plugin not maven-release because changing the maven-release mockito version broke many things. Not sure if this is correct.